### PR TITLE
Use DP private runner with adult dataset

### DIFF
--- a/FedFB/DP_load_dataset.py
+++ b/FedFB/DP_load_dataset.py
@@ -187,7 +187,7 @@ train = compas.iloc[: int(len(compas) * .7)]
 test  = compas.iloc[int(len(compas) * .7):]
 
 # 1) Dirichlet‑α 参数（可与 Adult 区域保持一致）
-NUM_CLIENTS            = 5    # 客户端数
+NUM_CLIENTS            = 3    # 客户端数
 ALPHA                  = 0.1  # Dirichlet α（越小→分布越不均匀）
 MIN_SAMPLES            = 100  # 每客户端最少样本
 MIN_SAMPLES_PER_GROUP  = 20   # 每客户端每个敏感组最少样本

--- a/FedFB/DP_run_private.py
+++ b/FedFB/DP_run_private.py
@@ -36,14 +36,15 @@ def run_dp(method, model, dataset, prn = True, seed = 123, ε = 1, trial = False
 
     # execute
     if method == 'fedfb':
-        acc, dpdisp, classifier = server.FedFB(**kwargs)
+        acc, dpdisp, eod, classifier = server.FedFB(**kwargs)
     elif method == 'fflfb':
-        acc, dpdisp, classifier = server.FFLFB(**kwargs)
+        acc, dpdisp, eod, classifier = server.FFLFB(**kwargs)
     else:
         Warning('Does not support this method!')
         exit(1)
 
-    if not trial: return {'accuracy': acc, 'DP Disp': dpdisp}
+    if not trial:
+        return {'accuracy': acc, 'DP Disp': dpdisp, 'EOD': eod}
 
 def sim_dp(method, model, dataset, ε = 1, num_sim = 5, seed = 0, resources_per_trial = {'cpu':4}, **kwargs):
     # choose the model
@@ -104,8 +105,8 @@ def sim_dp(method, model, dataset, ε = 1, num_sim = 5, seed = 0, resources_per_
         server = Server(arc(num_features=num_features, num_classes=2, seed = seed), info, ε = ε, train_prn = False, seed = seed, Z = Z, ret = True, prn = False)
         trained_model = copy.deepcopy(server.model)
         trained_model.load_state_dict(torch.load(os.path.join(best_trial.checkpoint.value, 'checkpoint')))
-        test_acc, n_yz = server.test_inference(trained_model)
-        df = pd.DataFrame([{'accuracy': test_acc, 'DP Disp': DPDisparity(n_yz)}])
+        test_acc, n_yz, test_eod = server.test_inference(trained_model)
+        df = pd.DataFrame([{'accuracy': test_acc, 'DP Disp': DPDisparity(n_yz), 'EOD': test_eod}])
 
         # use the same hyperparameters for other seeds
         for seed in range(1, num_sim):
@@ -159,8 +160,8 @@ def sim_dp(method, model, dataset, ε = 1, num_sim = 5, seed = 0, resources_per_
         server = Server(arc(num_features=num_features, num_classes=2, seed = seed), info, ε = ε, train_prn = False, seed = seed, Z = Z, ret = True, prn = False)
         trained_model = copy.deepcopy(server.model)
         trained_model.load_state_dict(torch.load(os.path.join(best_trial.checkpoint.value, 'checkpoint')))
-        test_acc, n_yz = server.test_inference(trained_model)
-        df = pd.DataFrame([{'accuracy': test_acc, 'DP Disp': DPDisparity(n_yz)}])
+        test_acc, n_yz, test_eod = server.test_inference(trained_model)
+        df = pd.DataFrame([{'accuracy': test_acc, 'DP Disp': DPDisparity(n_yz), 'EOD': test_eod}])
 
         # use the same hyperparameters for other seeds
         for seed in range(1, num_sim):

--- a/FedFB/DP_run_private.py
+++ b/FedFB/DP_run_private.py
@@ -182,13 +182,26 @@ def sim_dp(method, model, dataset, ε = 1, num_sim = 5, seed = 0, resources_per_
         exit(1)
 
 def sim_dp_man(method, model, dataset, ε = 1, num_sim = 5, seed = 0, **kwargs):
+    """Run multiple simulations with differential privacy and report statistics."""
     results = []
     for seed in range(num_sim):
-        results.append(run_dp(method, model, dataset, prn = True, ε = ε, seed = seed, trial = False, **kwargs))
+        results.append(
+            run_dp(method, model, dataset, prn=True, ε=ε, seed=seed, trial=False, **kwargs)
+        )
+
     df = pd.DataFrame(results)
-    acc_mean, rp_mean = df.mean()
-    acc_mean, dp_mean = df.mean()
-    acc_std, dp_std = df.std()
+
+    acc_mean = df['accuracy'].mean()
+    acc_std = df['accuracy'].std()
+    dp_mean = df['DP Disp'].mean()
+    dp_std = df['DP Disp'].std()
+    eod_mean = df['EOD'].mean()
+    eod_std = df['EOD'].std()
+
     print("Result across %d simulations: " % num_sim)
-    print("| Accuracy: %.4f(%.4f) | DP Disp: %.4f(%.4f)" % (acc_mean, acc_std, dp_mean, dp_std))
-    return acc_mean, acc_std, dp_mean, dp_std
+    print(
+        "| Accuracy: %.4f(%.4f) | DP Disp: %.4f(%.4f) | EOD: %.4f(%.4f)"
+        % (acc_mean, acc_std, dp_mean, dp_std, eod_mean, eod_std)
+    )
+
+    return acc_mean, acc_std, dp_mean, dp_std, eod_mean, eod_std

--- a/main.py
+++ b/main.py
@@ -1,18 +1,22 @@
-import sys, os
-working_dir = r'C:\Users\10733\Downloads\fedfb\fedfb'
+import os
+import sys
+
+# Add the library path
+working_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(1, os.path.join(working_dir, 'FedFB'))
-os.environ["PYTHONPATH"] = os.path.join(working_dir, 'FedFB')
 
-from DP_run import sim_dp, sim_dp_man
+from DP_run_private import sim_dp_man
 
-sim_dp_man(
-    method        ='fedfb',
-    model         ='multilayer perceptron',
-    dataset       ='compas',
-    num_sim       =1,
-    seed          =24,
-    num_rounds    =10,      # ← 通信轮数
-    local_epochs  =2,
-    learning_rate =0.001,
-    alpha         =1      # 公平性权重 λ
-)
+if __name__ == '__main__':
+    sim_dp_man(
+        method='fedfb',
+        model='multilayer perceptron',
+        dataset='adult',
+        ε=1,
+        num_sim=1,
+        seed=24,
+        num_rounds=10,
+        local_epochs=2,
+        learning_rate=0.001,
+        alpha=1
+    )


### PR DESCRIPTION
## Summary
- run the differential privacy version of FedFB from `DP_run_private`
- switch the main script to use the Adult dataset
- client level DP noise in the server aggregation
- compute and return EOD in the private server
- use Dirichlet split with 3 clients for COMPAS dataset

## Testing
- `python -m py_compile main.py FedFB/DP_server_private.py FedFB/DP_run_private.py FedFB/DP_load_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_6876607c4bf0832687156cb064c25694